### PR TITLE
Math equation style parameter and fix horizontally overflowing math equations

### DIFF
--- a/lib/latext.dart
+++ b/lib/latext.dart
@@ -144,11 +144,14 @@ class LaTexTState extends State<LaTexT> {
         );
       }
 
-      Widget tex = Math.tex(
-        texts[i].trim(),
-        textStyle: (widget.equationStyle != null)
-            ? widget.equationStyle
-            : widget.laTeXCode.style,
+      Widget tex = SingleChildScrollView(
+        scrollDirection: Axis.horizontal,
+        child: Math.tex(
+          texts[i].trim(),
+          textStyle: (widget.equationStyle != null)
+              ? widget.equationStyle
+              : widget.laTeXCode.style,
+        ),
       );
 
       if (align) {

--- a/lib/latext.dart
+++ b/lib/latext.dart
@@ -148,9 +148,7 @@ class LaTexTState extends State<LaTexT> {
         scrollDirection: Axis.horizontal,
         child: Math.tex(
           texts[i].trim(),
-          textStyle: (widget.equationStyle != null)
-              ? widget.equationStyle
-              : widget.laTeXCode.style,
+          textStyle: widget.equationStyle ?? widget.laTeXCode.style,
         ),
       );
 

--- a/lib/latext.dart
+++ b/lib/latext.dart
@@ -16,9 +16,14 @@ class LaTexT extends StatefulWidget {
   // The delimiter to be used for line breaks. Either \\ or \break.
   final String breakDelimiter;
 
+  // A TextStyle used to apply styles exclusively to the mathematical equations of the laTeXCode.
+  // If not provided, this variable will be ignored, and the laTeXCode style will be applied.
+  final TextStyle? equationStyle;
+
   const LaTexT({
     super.key,
     required this.laTeXCode,
+    this.equationStyle,
     this.delimiter = r'$',
     this.displayDelimiter = r'$$',
     this.breakDelimiter = r'\\',
@@ -141,7 +146,9 @@ class LaTexTState extends State<LaTexT> {
 
       Widget tex = Math.tex(
         texts[i].trim(),
-        textStyle: widget.laTeXCode.style,
+        textStyle: (widget.equationStyle != null)
+            ? widget.equationStyle
+            : widget.laTeXCode.style,
       );
 
       if (align) {


### PR DESCRIPTION
I had a problem, I needed the equations to have a different style from the text while reading the LaTeX document. So I added a parameter that gives the oportunity to change the textstyle of the math equation. If no parameter is given, the LaTeX style will be used as normal.

Also the big math equations were overflowing, so I added a SingleChildScrollView for horizontal scrolling to avoid this when it happens. I did not add any visual indicator of when a math equation is or is not scrollable, so it might be a little confusing. I might work on it later.